### PR TITLE
fix docker file by changing run to cmd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ WORKDIR /usr/src/app
 # use this to test a SLACK_TOKEN environment variable
 # ENV SLACK_TOKEN ###token###
 
-RUN python run.py
+CMD python run.py

--- a/slackbot/settings.py
+++ b/slackbot/settings.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 DEBUG = False
 
@@ -14,6 +15,7 @@ except:
     # Alternatively, place slack token in the source code
     # API_TOKEN = '###token###'
     print 'SLACK_TOKEN missing'
+    sys.exit(1)
 
 '''
 If you use Slack Web API to send messages (with send_webapi() or reply_webapi()),


### PR DESCRIPTION
I changed `RUN` to `CMD` so that the bot runs properly on beepboop.  I also added an exit for clearer messaging if the slack token is missing.
